### PR TITLE
Disable ASU by using environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ AWS_ASSUME_ROLE_NAME=session-name-for-role
 If you want to use different filename / path for your config file, you can use 
 `S3_MAVEN_CONFIG_FILE=<path-to-your-config-file>` environment variable.
 
+### Disabling ASU
+
+If you want to disable IAM roles usage (although you've set the environment variables), 
+e.g. for your CI system, you can do it by defining an environment variable
+`AWS_ASSUME_ROLE_DISABLED=true`. 
+
+
 #### Config precedence
 
 1. Use environment variables if they exist

--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ AWS_ASSUME_ROLE_NAME=session-name-for-role
 If you want to use different filename / path for your config file, you can use 
 `S3_MAVEN_CONFIG_FILE=<path-to-your-config-file>` environment variable.
 
-### Disabling ASU
-
-If you want to disable IAM roles usage (although you've set the environment variables), 
-e.g. for your CI system, you can do it by defining an environment variable
-`AWS_ASSUME_ROLE_DISABLED=true`. 
-
+If you want to disable ASU even though you've set the config file (e.g. in your
+CI environment), you can override the config variables with empty environment variables
+```
+export AWS_ASSUME_ROLE_ARN=
+export AWS_ASSUME_ROLE_NAME=
+```
 
 #### Config precedence
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>fi.yle.tools</groupId>
   <artifactId>aws-maven</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
   <name>Amazon Web Services S3 Maven Wagon Support</name>
   <description>Standard Maven wagon support for s3:// urls and IAM roles</description>
 

--- a/src/main/java/fi/yle/tools/aws/maven/SimpleStorageServiceWagon.java
+++ b/src/main/java/fi/yle/tools/aws/maven/SimpleStorageServiceWagon.java
@@ -53,6 +53,8 @@ public final class SimpleStorageServiceWagon extends AbstractWagon {
 
     private static final String RESOURCE_FORMAT = "%s(.*)";
 
+    private static final String asuDisabledKey = "AWS_ASSUME_ROLE_DISABLED";
+
     private static final String roleArnKey = "AWS_ASSUME_ROLE_ARN";
 
     private static final String roleSessionName = "AWS_ASSUME_ROLE_NAME";
@@ -159,6 +161,10 @@ public final class SimpleStorageServiceWagon extends AbstractWagon {
     }
 
     protected boolean isAssumedRoleRequested() {
+        String disabled = System.getenv(asuDisabledKey);
+        if (disabled != null && ("true".equals(disabled.toLowerCase()) || "1".equals(disabled))) {
+            return false;
+        }
         return getAssumedRoleARN() != null && getAssumedRoleSessionName() != null;
     }
 

--- a/src/main/java/fi/yle/tools/aws/maven/SimpleStorageServiceWagon.java
+++ b/src/main/java/fi/yle/tools/aws/maven/SimpleStorageServiceWagon.java
@@ -53,8 +53,6 @@ public final class SimpleStorageServiceWagon extends AbstractWagon {
 
     private static final String RESOURCE_FORMAT = "%s(.*)";
 
-    private static final String asuDisabledKey = "AWS_ASSUME_ROLE_DISABLED";
-
     private static final String roleArnKey = "AWS_ASSUME_ROLE_ARN";
 
     private static final String roleSessionName = "AWS_ASSUME_ROLE_NAME";
@@ -161,11 +159,9 @@ public final class SimpleStorageServiceWagon extends AbstractWagon {
     }
 
     protected boolean isAssumedRoleRequested() {
-        String disabled = System.getenv(asuDisabledKey);
-        if (disabled != null && ("true".equals(disabled.toLowerCase()) || "1".equals(disabled))) {
-            return false;
-        }
-        return getAssumedRoleARN() != null && getAssumedRoleSessionName() != null;
+        String role = getAssumedRoleARN();
+        String session = getAssumedRoleSessionName();
+        return role != null && session != null && !role.trim().isEmpty() && !session.trim().isEmpty();
     }
 
     @Override


### PR DESCRIPTION
ASU role can be disabled by setting an environment variable `AWS_ASSUME_ROLE_DISABLED=true`.

This is needed because CI users might not need to use IAM roles, although developers have to.
