### PR TITLE
Update README.md to use pluginRepository

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ To get the dependency add to your pom:
 
 
 ```xml
-<repositories>
-    <repository>
+<pluginRepositories>
+    <pluginRepository>
       <id>yle-public</id>
       <name>Yle public repository</name>
       <url>http://maven.c4.yle.fi/release</url>
       <layout>default</layout>
-    </repository>
-</repositories>
+    </pluginRepository>
+</pluginRepositories>
 ```
 
 And plugin dependency:


### PR DESCRIPTION
To add a repository to install a plugin the repository should be
specified using `pluginRepositories` not `repositories` in the pom.xml