### PR TITLE
Add explicit JAXB dependencies for Java 9 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,21 @@
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.2.11</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Siirrettäessä ovp-schemaa Java 9:ään huomattiin, että aws-maven räjähtää [puuttuviin JAXB-riippuvuuksiin](https://travis-ci.com/Yleisradio/ovp-schema/builds/69529266), koska moiset ovat [siirtyneet pois oletus-classpathista](https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j).

Koska leiningen-projektin java-opts-vivut eivät vaikuta pluginien toimintaan, tämän pularin pitäisi korjata ongelma sen alkulähteillä.