### PR TITLE
Minio support

### DIFF
--- a/src/main/java/fi/yle/tools/aws/maven/AuthenticationInfoAWSCredentialsProviderChain.java
+++ b/src/main/java/fi/yle/tools/aws/maven/AuthenticationInfoAWSCredentialsProviderChain.java
@@ -28,8 +28,8 @@ final class AuthenticationInfoAWSCredentialsProviderChain extends AWSCredentials
     AuthenticationInfoAWSCredentialsProviderChain(AuthenticationInfo authenticationInfo) {
         super(new EnvironmentVariableCredentialsProvider(),
                 new SystemPropertiesCredentialsProvider(),
-                new InstanceProfileCredentialsProvider(),
+                new AuthenticationInfoAWSCredentialsProvider(authenticationInfo),
                 new ProfileCredentialsProvider(),
-                new AuthenticationInfoAWSCredentialsProvider(authenticationInfo));
+                new InstanceProfileCredentialsProvider());
     }
 }


### PR DESCRIPTION
Solves #19

Adds MinIO support through Maven's settings.xml and System properties. Here's what a sample Maven configuration would look like:

```
<servers>
  <server>
    <id>minio-release</id>
    <username>291cafe6-eceb-43dc-91b3-58be867d9da2</username>
    <password>e383fed0-4645-45f6-acea-65f3748b96c8</password>
    <configuration>
      <wagonProvider>s3</wagonProvider>
      <s3Provider>minio</s3Provider>
      <endpoint>https://minio-tenant-1-hl.minio-tenant-1.svc.cluster:4430</endpoint>
    </configuration>
  </server>
  <server>
    <id>minio-snapshot</id>
    <username>291cafe6-eceb-43dc-91b3-58be867d9da2</username>
    <password>e383fed0-4645-45f6-acea-65f3748b96c8</password>
    <configuration>
      <wagonProvider>s3</wagonProvider>
      <s3Provider>minio</s3Provider>
      <endpoint>https://minio-tenant-1-hl.minio-tenant-1.svc.cluster:4430</endpoint>
    </configuration>
  </server>
</servers>
```

...
```
<repositories>
  <repository>
    <id>minio-release</id>
    <name>MinIO Release Repository</name>
    <url>s3://maven/release</url>
  </repository>
  <repository>
    <id>minio-snapshot</id>
    <name>MinIO Snapshot Repository</name>
    <url>s3://maven/snapshot</url>
  </repository>
</repositories>
```


Thanks !